### PR TITLE
chore(deps): upgrade soroban-sdk to 27.0.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1354,9 +1354,9 @@ checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "soroban-builtin-sdk-macros"
-version = "27.0.0"
+version = "27.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d769030e3b2c27873e9be4931decbbe79787b943d5b30e31f8c395eae83144b8"
+checksum = "b77bc93d930032c487cb1506b6ed166b2af49db76d52678ec4887ac621ecce01"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -1366,9 +1366,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-common"
-version = "27.0.0"
+version = "27.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aa50d998c0baafcc6078cb94f5228040c7719b1608c15debc3fc78365dc22f5"
+checksum = "6b22e9981cdd444f3aa6734bc58d76195bf7eca3ccf1dd432b875af5d02da068"
 dependencies = [
  "arbitrary",
  "crate-git-revision 0.0.6",
@@ -1385,9 +1385,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-guest"
-version = "27.0.0"
+version = "27.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fde1064f5e92dbcc8018ecc8e92728bf5bbff0236abaf792c6858367a6853415"
+checksum = "2b6072f99ca6bf8e8d5b04e05d083dac785e5357d9c0f36a6658f819c2fd7d67"
 dependencies = [
  "soroban-env-common",
  "static_assertions",
@@ -1395,9 +1395,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-host"
-version = "27.0.0"
+version = "27.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f47762a1b75b9ccd07558f28e1a0289ca6adec56810c581cde5cf16e329e00b9"
+checksum = "2c06afd7c75ce150ce53e4d77a77645b18e3fb61856a0ddc42bfcecdc39fa3b9"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -1432,9 +1432,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-macros"
-version = "27.0.0"
+version = "27.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc04b813a9e32456b37875fc41cdb05912a9e947000b9414b7985bffe07a889a"
+checksum = "647811bdd28a3ec40296987f6635781e5e1141c8f5affbbd53ba12b6295b7bb6"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -1447,9 +1447,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-ledger-snapshot"
-version = "27.0.0"
+version = "27.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e4bf41f85da648dca4153ca5ed41411658d2029e15d9ba693fdd2e3e5dbe05d"
+checksum = "8c2e5349579373161730c723b18de6b7f982c5751ed45129f9500b991cb700a3"
 dependencies = [
  "serde",
  "serde_json",
@@ -1461,9 +1461,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk"
-version = "27.0.0"
+version = "27.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5636f9d62dd0cc6d23f08f775aa60f712ec596e5761f6911aee154337d401bf"
+checksum = "b1492575be91ff70955bff7deac44a97532a06cafc9f31bede0ed521771e6e1f"
 dependencies = [
  "arbitrary",
  "bytes-lit",
@@ -1485,9 +1485,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk-macros"
-version = "27.0.0"
+version = "27.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c9f001d91196d9cd659634f9113f75609819204aef5fae27b4ab845cdfc741"
+checksum = "25d9617d9b536a9390800c43323b0a1ec788bba624e98ffbba53379dd1c4b293"
 dependencies = [
  "darling 0.20.11",
  "heck",
@@ -1505,9 +1505,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec"
-version = "27.0.0"
+version = "27.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca1e22ce713871c6f9d21a321051b58e53080629b6a5be1132cf11f42cca4d10"
+checksum = "38951bbbdda988fb3c1718c146e641a7b3f652fc1e071ee55b0094d3f6184759"
 dependencies = [
  "base64",
  "sha2",
@@ -1518,9 +1518,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec-rust"
-version = "27.0.0"
+version = "27.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89fb158f79ec527e46a5d5162f11c4269e17748e6b69391cdf648133d76cfead"
+checksum = "d4df5d7a081968df57cd27d4f65f42fb469ffd11d3b28fb79a02fb532ab6db91"
 dependencies = [
  "prettyplease",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 resolver = "2"
 
 [workspace.dependencies]
-soroban-sdk = "27.0.0"
+soroban-sdk = "27.0.4"
 
 [profile.release]
 opt-level = "z"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   <p>
     <img src="https://img.shields.io/github/actions/workflow/status/accensa/accensa-contracts/ci.yml?branch=main" alt="CI Status" />
     <img src="https://img.shields.io/badge/License-MIT-blue.svg" alt="License" />
-    <img src="https://img.shields.io/badge/soroban--sdk-27.0.0-orange.svg" alt="soroban-sdk 27" />
+    <img src="https://img.shields.io/badge/soroban--sdk-27.0.4-orange.svg" alt="soroban-sdk 27" />
     <img src="https://img.shields.io/badge/testnet-deployed-success.svg" alt="Deployed on testnet" />
   </p>
   <p>


### PR DESCRIPTION
The lockfile pinned `27.0.0` while `27.0.4` was current, and `Cargo.toml` declared `27.0.0` as well — so the manifest and the README badge both advertised a version four patches behind the ecosystem.

`cargo update -p soroban-sdk` moved the SDK and its env/spec crates forward; `Cargo.toml` and the badge now state `27.0.4` rather than leaving a stale constraint behind the lock.

## No deprecations to resolve

The issue anticipated deprecation fallout. There is none — nothing this codebase uses changed API between 27.0.0 and 27.0.4. Clippy at `-D warnings` is clean and no deprecation warnings appear.

## Verified

```
cargo fmt --all -- --check              clean
cargo clippy --all-targets -D warnings  clean
cargo test                              28 passed, 0 failed
cargo build --target wasm32v1-none      receipt_anchor 15234 B, refund_vault 13324 B
```

## Not redeploying

The deployed testnet contracts are unaffected: this changes the source dependency, not the anchored wasm. Redeploying would mint new contract IDs and invalidate the ones published in `DEPLOYMENTS.md`, the READMEs, and the live verifier — so it is deliberately out of scope here.

Closes #21.