### PR TITLE
feat(receipt-anchor): enforce max batch size and expose batch count

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,9 @@ they were charged correctly, with no trusted API in the path.
 | Function | Purpose |
 |---|---|
 | `initialize(merchant)` | Binds the contract to a merchant admin address. |
-| `anchor_batch(root, count, period_start, period_end) -> u64` | Anchors a batch root, returns its `batch_id`. Merchant auth required. |
+| `anchor_batch(root, count, period_start, period_end) -> u64` | Anchors a batch root, returns its `batch_id`. Merchant auth required. `count` must be $\le$ 1000 (`MAX_BATCH_SIZE`). |
 | `get_batch(batch_id) -> BatchRecord` | Reads an anchored batch. |
+| `get_batch_count() -> u64` | Returns the total number of anchored batches. Read-only. |
 | `verify_receipt(batch_id, leaf, proof) -> bool` | Verifies a receipt against the anchored root. Read-only, free to call. |
 
 Emits `Anchored` with topics `("anchored", batch_id)`.

--- a/contracts/receipt-anchor/src/lib.rs
+++ b/contracts/receipt-anchor/src/lib.rs
@@ -11,6 +11,7 @@ pub enum Error {
     NotInitialized = 2,
     Unauthorized = 3,
     BatchNotFound = 4,
+    BatchTooLarge = 5,
 }
 
 #[contracttype]
@@ -44,6 +45,8 @@ pub struct Anchored {
     pub period_end: u64,
 }
 
+const MAX_BATCH_SIZE: u32 = 1000;
+
 #[contract]
 pub struct ReceiptAnchor;
 
@@ -66,6 +69,10 @@ impl ReceiptAnchor {
         period_start: u64,
         period_end: u64,
     ) -> Result<u64, Error> {
+        if count > MAX_BATCH_SIZE {
+            return Err(Error::BatchTooLarge);
+        }
+
         let merchant: Address = env
             .storage()
             .instance()
@@ -140,6 +147,13 @@ impl ReceiptAnchor {
         }
 
         Ok(computed_hash == batch.root.to_array())
+    }
+
+    pub fn get_batch_count(env: Env) -> Result<u64, Error> {
+        env.storage()
+            .instance()
+            .get(&DataKey::BatchCount)
+            .ok_or(Error::NotInitialized)
     }
 }
 

--- a/contracts/receipt-anchor/src/test.rs
+++ b/contracts/receipt-anchor/src/test.rs
@@ -168,6 +168,39 @@ fn test_verify_receipt_missing_batch_fails() {
     );
 }
 
+#[test]
+fn test_get_batch_count_tracks_anchors() {
+    let (env, client, merchant) = setup();
+    client.initialize(&merchant);
+
+    assert_eq!(client.get_batch_count(), 0);
+
+    let root = BytesN::from_array(&env, &[1u8; 32]);
+    client.anchor_batch(&root, &5, &0, &50);
+    assert_eq!(client.get_batch_count(), 1);
+
+    client.anchor_batch(&root, &7, &51, &99);
+    assert_eq!(client.get_batch_count(), 2);
+}
+
+#[test]
+fn test_get_batch_count_before_initialize_fails() {
+    let (_env, client, _merchant) = setup();
+    assert_eq!(client.try_get_batch_count(), Err(Ok(Error::NotInitialized)));
+}
+
+#[test]
+fn test_anchor_batch_enforces_max_size() {
+    let (env, client, merchant) = setup();
+    client.initialize(&merchant);
+
+    let root = BytesN::from_array(&env, &[1u8; 32]);
+    assert_eq!(
+        client.try_anchor_batch(&root, &1001, &0, &50),
+        Err(Ok(Error::BatchTooLarge))
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Cross-implementation conformance
 // ---------------------------------------------------------------------------

--- a/contracts/receipt-anchor/test_snapshots/test/test_anchor_batch_enforces_max_size.1.json
+++ b/contracts/receipt-anchor/test_snapshots/test/test_anchor_batch_enforces_max_size.1.json
@@ -1,0 +1,87 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 27,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": [
+                    {
+                      "key": {
+                        "vec": [
+                          {
+                            "symbol": "Admin"
+                          }
+                        ]
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "vec": [
+                          {
+                            "symbol": "BatchCount"
+                          }
+                        ]
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": []
+}

--- a/contracts/receipt-anchor/test_snapshots/test/test_get_batch_count_before_initialize_fails.1.json
+++ b/contracts/receipt-anchor/test_snapshots/test/test_get_batch_count_before_initialize_fails.1.json
@@ -1,0 +1,61 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 27,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": null
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": []
+}

--- a/contracts/receipt-anchor/test_snapshots/test/test_get_batch_count_tracks_anchors.1.json
+++ b/contracts/receipt-anchor/test_snapshots/test/test_get_batch_count_tracks_anchors.1.json
@@ -1,0 +1,305 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "anchor_batch",
+              "args": [
+                {
+                  "bytes": "0101010101010101010101010101010101010101010101010101010101010101"
+                },
+                {
+                  "u32": 5
+                },
+                {
+                  "u64": "0"
+                },
+                {
+                  "u64": "50"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "anchor_batch",
+              "args": [
+                {
+                  "bytes": "0101010101010101010101010101010101010101010101010101010101010101"
+                },
+                {
+                  "u32": 7
+                },
+                {
+                  "u64": "51"
+                },
+                {
+                  "u64": "99"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 27,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "Batch"
+                  },
+                  {
+                    "u64": "1"
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "map": [
+                  {
+                    "key": {
+                      "symbol": "count"
+                    },
+                    "val": {
+                      "u32": 5
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "period_end"
+                    },
+                    "val": {
+                      "u64": "50"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "period_start"
+                    },
+                    "val": {
+                      "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "root"
+                    },
+                    "val": {
+                      "bytes": "0101010101010101010101010101010101010101010101010101010101010101"
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "Batch"
+                  },
+                  {
+                    "u64": "2"
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "map": [
+                  {
+                    "key": {
+                      "symbol": "count"
+                    },
+                    "val": {
+                      "u32": 7
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "period_end"
+                    },
+                    "val": {
+                      "u64": "99"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "period_start"
+                    },
+                    "val": {
+                      "u64": "51"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "root"
+                    },
+                    "val": {
+                      "bytes": "0101010101010101010101010101010101010101010101010101010101010101"
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": [
+                    {
+                      "key": {
+                        "vec": [
+                          {
+                            "symbol": "Admin"
+                          }
+                        ]
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "vec": [
+                          {
+                            "symbol": "BatchCount"
+                          }
+                        ]
+                      },
+                      "val": {
+                        "u64": "2"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "801925984706572462"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "5541220902715666415"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": []
+}


### PR DESCRIPTION
## Summary
This PR bundles two related additions to the `receipt-anchor` contract to improve usability for indexers and prevent out-of-gas errors from oversized batches.

## What changed
- Exposed a `get_batch_count() -> u64` read function to allow indexers to easily fetch the latest batch ID without probing.
- Added a `MAX_BATCH_SIZE` constant (set to 1000).
- Updated `anchor_batch` to enforce `count <= MAX_BATCH_SIZE`, returning `BatchTooLarge = 5` if exceeded.
- Added unit tests for both behaviors.
- Updated `README.md` to document the new method and constraint.

## Acceptance Criteria
**#8**
- [x] `get_batch_count() -> u64` public read function.
- [x] Test asserting it tracks `anchor_batch` calls.
- [x] Documented in the contract reference.

**#15**
- [x] Define a `MAX_BATCH_SIZE` constant (set to 1000).
- [x] Check the input batch length in `anchor_batch` and return a specific `BatchTooLarge` error if exceeded.
- [x] Document this constraint in the contract's public interfaces.
- [x] Test the error condition using a mocked large input.

Closes #8
Closes #15
