### PR TITLE
feat(refund-vault): add pausing functionality for emergency stops

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ Holds merchant float and executes refunds bounded by an on-chain policy.
 | `withdraw(amount, to)` | Merchant withdraws float. |
 | `set_refund_window(ledgers)` | Updates the window; `0` disables expiry. |
 | `get_refund(payment_ref) -> Option<RefundRecord>` | Looks up a refund. |
+| `pause()` | Pauses operations for emergency stops. Merchant auth required. |
+| `unpause()` | Resumes paused operations. Merchant auth required. |
 
 Emits `Refunded` with topics `("refunded", payment_ref)`.
 
@@ -97,6 +99,7 @@ Enforced invariants, each covered by a test:
 - **Time-bounded** — refunds past `refund_window_ledgers` are rejected (`WindowExpired`).
 - **Float-bounded** — a refund can never exceed vault balance (`InsufficientFloat`).
 - **Merchant-only** — every state-changing call requires merchant auth (`Unauthorized`).
+- **Pausable** — operations are halted if the vault is paused (`Paused`).
 
 ## Live on Testnet
 

--- a/contracts/refund-vault/src/lib.rs
+++ b/contracts/refund-vault/src/lib.rs
@@ -14,6 +14,7 @@ pub enum Error {
     WindowExpired = 5,
     InsufficientFloat = 6,
     InvalidAmount = 7,
+    Paused = 8,
 }
 
 #[contracttype]
@@ -22,6 +23,7 @@ pub enum DataKey {
     Token,
     RefundWindow,
     Refund(BytesN<32>),
+    IsPaused,
 }
 
 #[contracttype]
@@ -70,6 +72,15 @@ impl RefundVault {
     }
 
     pub fn deposit(env: Env, from: Address, amount: i128) -> Result<(), Error> {
+        if env
+            .storage()
+            .instance()
+            .get(&DataKey::IsPaused)
+            .unwrap_or(false)
+        {
+            return Err(Error::Paused);
+        }
+
         if amount <= 0 {
             return Err(Error::InvalidAmount);
         }
@@ -101,6 +112,15 @@ impl RefundVault {
         amount: i128,
         paid_at_ledger: u32,
     ) -> Result<(), Error> {
+        if env
+            .storage()
+            .instance()
+            .get(&DataKey::IsPaused)
+            .unwrap_or(false)
+        {
+            return Err(Error::Paused);
+        }
+
         if amount <= 0 {
             return Err(Error::InvalidAmount);
         }
@@ -168,6 +188,15 @@ impl RefundVault {
     }
 
     pub fn withdraw(env: Env, amount: i128, to: Address) -> Result<(), Error> {
+        if env
+            .storage()
+            .instance()
+            .get(&DataKey::IsPaused)
+            .unwrap_or(false)
+        {
+            return Err(Error::Paused);
+        }
+
         if amount <= 0 {
             return Err(Error::InvalidAmount);
         }
@@ -211,6 +240,32 @@ impl RefundVault {
         env.storage()
             .persistent()
             .get(&DataKey::Refund(payment_ref))
+    }
+
+    pub fn pause(env: Env) -> Result<(), Error> {
+        let merchant: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::NotInitialized)?;
+        merchant.require_auth();
+
+        env.storage().instance().set(&DataKey::IsPaused, &true);
+        env.storage().instance().extend_ttl(100, 100000);
+        Ok(())
+    }
+
+    pub fn unpause(env: Env) -> Result<(), Error> {
+        let merchant: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::NotInitialized)?;
+        merchant.require_auth();
+
+        env.storage().instance().set(&DataKey::IsPaused, &false);
+        env.storage().instance().extend_ttl(100, 100000);
+        Ok(())
     }
 }
 

--- a/contracts/refund-vault/src/test.rs
+++ b/contracts/refund-vault/src/test.rs
@@ -264,3 +264,52 @@ fn test_withdraw_invalid_amount_fails() {
         Err(Ok(Error::InvalidAmount))
     );
 }
+
+#[test]
+fn test_pause_unpause() {
+    let (_env, client, _merchant, _token) = setup(100);
+    client.pause();
+    client.unpause();
+}
+
+#[test]
+fn test_deposit_when_paused_fails() {
+    let (_env, client, merchant, _token) = setup(100);
+    client.pause();
+    assert_eq!(client.try_deposit(&merchant, &100), Err(Ok(Error::Paused)));
+}
+
+#[test]
+fn test_refund_when_paused_fails() {
+    let (env, client, _merchant, _token) = setup(100);
+    client.pause();
+    let payment_ref = BytesN::from_array(&env, &[10u8; 32]);
+    let buyer = Address::generate(&env);
+    assert_eq!(
+        client.try_refund(&payment_ref, &buyer, &100, &0),
+        Err(Ok(Error::Paused))
+    );
+}
+
+#[test]
+fn test_withdraw_when_paused_fails() {
+    let (_env, client, merchant, _token) = setup(100);
+    client.pause();
+    assert_eq!(client.try_withdraw(&100, &merchant), Err(Ok(Error::Paused)));
+}
+
+#[test]
+#[should_panic]
+fn test_pause_requires_merchant_auth() {
+    let (env, client, _merchant, _token) = setup(100);
+    env.set_auths(&[]);
+    client.pause();
+}
+
+#[test]
+#[should_panic]
+fn test_unpause_requires_merchant_auth() {
+    let (env, client, _merchant, _token) = setup(100);
+    env.set_auths(&[]);
+    client.unpause();
+}


### PR DESCRIPTION
## Summary
This PR introduces a circuit breaker to the `RefundVault`. In the event of an operational anomaly or vulnerability, the admin can now immediately pause all float-draining functions (`deposit`, `refund`, and `withdraw`), protecting the remaining funds while the situation is investigated.

## What changed
- Added `Paused = 8` to the `Error` enum and `IsPaused` to `DataKey`.
- Implemented `pause()` and `unpause()` functions restricted to the admin.
- Added short-circuit checks at the start of `deposit`, `refund`, and `withdraw` that revert with `Error::Paused` if the contract is paused.
- Added comprehensive tests for `pause()`, `unpause()`, and the reverted state-changing calls.
- Updated `README.md` to document the new functions and the `Pausable` invariant.

## Acceptance Criteria
- [x] Add `pause()` and `unpause()` functions restricted to the admin.
- [x] Check the pause state in `deposit`, `refund`, and `withdraw` and revert if paused.
- [x] Document the emergency flow and write tests verifying the paused states.

Closes #18
