### PR TITLE
feat(contracts): deliberate storage TTL strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ they were charged correctly, with no trusted API in the path.
 | `get_batch(batch_id) -> BatchRecord` | Reads an anchored batch. |
 | `get_batch_count() -> u64` | Returns the total number of anchored batches. Read-only. |
 | `verify_receipt(batch_id, leaf, proof) -> bool` | Verifies a receipt against the anchored root. Read-only, free to call. |
+| `extend_batch_ttl(batch_id)` | Extends the TTL of a batch to prevent archival. Publicly callable. |
 
 Emits `Anchored` with topics `("anchored", batch_id)`.
 
@@ -90,6 +91,7 @@ Holds merchant float and executes refunds bounded by an on-chain policy.
 | `get_refund(payment_ref) -> Option<RefundRecord>` | Looks up a refund. |
 | `pause()` | Pauses operations for emergency stops. Merchant auth required. |
 | `unpause()` | Resumes paused operations. Merchant auth required. |
+| `extend_refund_ttl(payment_ref)` | Extends the TTL of a refund record to prevent archival. Publicly callable. |
 
 Emits `Refunded` with topics `("refunded", payment_ref)`.
 
@@ -100,6 +102,14 @@ Enforced invariants, each covered by a test:
 - **Float-bounded** — a refund can never exceed vault balance (`InsufficientFloat`).
 - **Merchant-only** — every state-changing call requires merchant auth (`Unauthorized`).
 - **Pausable** — operations are halted if the vault is paused (`Paused`).
+
+## Storage Archival
+
+Soroban uses state archival to manage ledger bloat. The contracts are configured with a Time-To-Live (TTL) strategy that ensures active records remain in persistent storage for approximately 30 days (~518,400 ledgers) before they become eligible for archival.
+
+If a `BatchRecord` or `RefundRecord` is archived, it must be restored by submitting a restore transaction before it can be read again. Anyone can proactively prevent archival and reset the 30-day window by calling the public TTL extension functions:
+- `extend_batch_ttl(batch_id)` on `ReceiptAnchor`
+- `extend_refund_ttl(payment_ref)` on `RefundVault`
 
 ## Live on Testnet
 

--- a/contracts/receipt-anchor/src/lib.rs
+++ b/contracts/receipt-anchor/src/lib.rs
@@ -65,7 +65,9 @@ impl ReceiptAnchor {
         }
         env.storage().instance().set(&DataKey::Admin, &merchant);
         env.storage().instance().set(&DataKey::BatchCount, &0u64);
-        env.storage().instance().extend_ttl(TTL_THRESHOLD, TTL_EXTEND);
+        env.storage()
+            .instance()
+            .extend_ttl(TTL_THRESHOLD, TTL_EXTEND);
         Ok(())
     }
 
@@ -104,7 +106,9 @@ impl ReceiptAnchor {
             .instance()
             .set(&DataKey::BatchCount, &batch_id);
 
-        env.storage().instance().extend_ttl(TTL_THRESHOLD, TTL_EXTEND);
+        env.storage()
+            .instance()
+            .extend_ttl(TTL_THRESHOLD, TTL_EXTEND);
         env.storage()
             .persistent()
             .extend_ttl(&DataKey::Batch(batch_id), TTL_THRESHOLD, TTL_EXTEND);

--- a/contracts/receipt-anchor/src/lib.rs
+++ b/contracts/receipt-anchor/src/lib.rs
@@ -45,6 +45,13 @@ pub struct Anchored {
     pub period_end: u64,
 }
 
+/// Approximately 30 days of ledgers, assuming ~5 seconds per ledger.
+/// 60 * 60 * 24 * 30 / 5 = 518,400.
+/// This ensures batches survive for long-term audit use before requiring a TTL bump or restoration.
+const TTL_EXTEND: u32 = 518_400;
+/// The threshold before TTL is actually bumped, to prevent spamming updates on every call.
+const TTL_THRESHOLD: u32 = 100;
+
 const MAX_BATCH_SIZE: u32 = 1000;
 
 #[contract]
@@ -58,7 +65,7 @@ impl ReceiptAnchor {
         }
         env.storage().instance().set(&DataKey::Admin, &merchant);
         env.storage().instance().set(&DataKey::BatchCount, &0u64);
-        env.storage().instance().extend_ttl(100, 100000);
+        env.storage().instance().extend_ttl(TTL_THRESHOLD, TTL_EXTEND);
         Ok(())
     }
 
@@ -97,10 +104,10 @@ impl ReceiptAnchor {
             .instance()
             .set(&DataKey::BatchCount, &batch_id);
 
-        env.storage().instance().extend_ttl(100, 100000);
+        env.storage().instance().extend_ttl(TTL_THRESHOLD, TTL_EXTEND);
         env.storage()
             .persistent()
-            .extend_ttl(&DataKey::Batch(batch_id), 100, 100000);
+            .extend_ttl(&DataKey::Batch(batch_id), TTL_THRESHOLD, TTL_EXTEND);
 
         Anchored {
             batch_id,
@@ -154,6 +161,16 @@ impl ReceiptAnchor {
             .instance()
             .get(&DataKey::BatchCount)
             .ok_or(Error::NotInitialized)
+    }
+
+    pub fn extend_batch_ttl(env: Env, batch_id: u64) -> Result<(), Error> {
+        if !env.storage().persistent().has(&DataKey::Batch(batch_id)) {
+            return Err(Error::BatchNotFound);
+        }
+        env.storage()
+            .persistent()
+            .extend_ttl(&DataKey::Batch(batch_id), TTL_THRESHOLD, TTL_EXTEND);
+        Ok(())
     }
 }
 

--- a/contracts/receipt-anchor/src/test.rs
+++ b/contracts/receipt-anchor/src/test.rs
@@ -201,6 +201,28 @@ fn test_anchor_batch_enforces_max_size() {
     );
 }
 
+#[test]
+fn test_extend_batch_ttl_fails_if_missing() {
+    let (_env, client, merchant) = setup();
+    client.initialize(&merchant);
+    assert_eq!(
+        client.try_extend_batch_ttl(&99),
+        Err(Ok(Error::BatchNotFound))
+    );
+}
+
+#[test]
+fn test_extend_batch_ttl_succeeds() {
+    let (env, client, merchant) = setup();
+    client.initialize(&merchant);
+
+    let root = BytesN::from_array(&env, &[1u8; 32]);
+    let batch_id = client.anchor_batch(&root, &5, &0, &50);
+
+    // This won't fail since the batch exists. (TTL updates aren't observable from the contract API, but it shouldn't revert)
+    client.extend_batch_ttl(&batch_id);
+}
+
 // ---------------------------------------------------------------------------
 // Cross-implementation conformance
 // ---------------------------------------------------------------------------

--- a/contracts/refund-vault/src/lib.rs
+++ b/contracts/refund-vault/src/lib.rs
@@ -15,6 +15,7 @@ pub enum Error {
     InsufficientFloat = 6,
     InvalidAmount = 7,
     Paused = 8,
+    RefundNotFound = 9,
 }
 
 #[contracttype]
@@ -48,6 +49,13 @@ pub struct Refunded {
     pub ledger: u32,
 }
 
+/// Approximately 30 days of ledgers, assuming ~5 seconds per ledger.
+/// 60 * 60 * 24 * 30 / 5 = 518,400.
+/// This ensures refund records survive long-term audit use before requiring a TTL bump or restoration.
+const TTL_EXTEND: u32 = 518_400;
+/// The threshold before TTL is actually bumped, to prevent spamming updates on every call.
+const TTL_THRESHOLD: u32 = 100;
+
 #[contract]
 pub struct RefundVault;
 
@@ -67,7 +75,8 @@ impl RefundVault {
         env.storage()
             .instance()
             .set(&DataKey::RefundWindow, &refund_window_ledgers);
-        env.storage().instance().extend_ttl(100, 100000);
+
+        env.storage().instance().extend_ttl(TTL_THRESHOLD, TTL_EXTEND);
         Ok(())
     }
 
@@ -96,12 +105,11 @@ impl RefundVault {
             return Err(Error::Unauthorized);
         }
 
-        let token_addr: Address = env.storage().instance().get(&DataKey::Token).unwrap();
-        let token_client = token::Client::new(&env, &token_addr);
-        let vault = env.current_contract_address();
-        token_client.transfer(&merchant, &vault, &amount);
+        let token: Address = env.storage().instance().get(&DataKey::Token).unwrap();
+        let client = token::Client::new(&env, &token);
+        client.transfer(&from, &env.current_contract_address(), &amount);
 
-        env.storage().instance().extend_ttl(100, 100000);
+        env.storage().instance().extend_ttl(TTL_THRESHOLD, TTL_EXTEND);
         Ok(())
     }
 
@@ -171,10 +179,10 @@ impl RefundVault {
             .persistent()
             .set(&DataKey::Refund(payment_ref.clone()), &record);
 
-        env.storage().instance().extend_ttl(100, 100000);
+        env.storage().instance().extend_ttl(TTL_THRESHOLD, TTL_EXTEND);
         env.storage()
             .persistent()
-            .extend_ttl(&DataKey::Refund(payment_ref.clone()), 100, 100000);
+            .extend_ttl(&DataKey::Refund(payment_ref.clone()), TTL_THRESHOLD, TTL_EXTEND);
 
         Refunded {
             payment_ref,
@@ -217,7 +225,7 @@ impl RefundVault {
 
         token_client.transfer(&env.current_contract_address(), &to, &amount);
 
-        env.storage().instance().extend_ttl(100, 100000);
+        env.storage().instance().extend_ttl(TTL_THRESHOLD, TTL_EXTEND);
         Ok(())
     }
 
@@ -232,7 +240,8 @@ impl RefundVault {
         env.storage()
             .instance()
             .set(&DataKey::RefundWindow, &ledgers);
-        env.storage().instance().extend_ttl(100, 100000);
+
+        env.storage().instance().extend_ttl(TTL_THRESHOLD, TTL_EXTEND);
         Ok(())
     }
 
@@ -251,7 +260,7 @@ impl RefundVault {
         merchant.require_auth();
 
         env.storage().instance().set(&DataKey::IsPaused, &true);
-        env.storage().instance().extend_ttl(100, 100000);
+        env.storage().instance().extend_ttl(TTL_THRESHOLD, TTL_EXTEND);
         Ok(())
     }
 
@@ -264,7 +273,17 @@ impl RefundVault {
         merchant.require_auth();
 
         env.storage().instance().set(&DataKey::IsPaused, &false);
-        env.storage().instance().extend_ttl(100, 100000);
+        env.storage().instance().extend_ttl(TTL_THRESHOLD, TTL_EXTEND);
+        Ok(())
+    }
+
+    pub fn extend_refund_ttl(env: Env, payment_ref: BytesN<32>) -> Result<(), Error> {
+        if !env.storage().persistent().has(&DataKey::Refund(payment_ref.clone())) {
+            return Err(Error::RefundNotFound);
+        }
+        env.storage()
+            .persistent()
+            .extend_ttl(&DataKey::Refund(payment_ref), TTL_THRESHOLD, TTL_EXTEND);
         Ok(())
     }
 }

--- a/contracts/refund-vault/src/lib.rs
+++ b/contracts/refund-vault/src/lib.rs
@@ -76,7 +76,9 @@ impl RefundVault {
             .instance()
             .set(&DataKey::RefundWindow, &refund_window_ledgers);
 
-        env.storage().instance().extend_ttl(TTL_THRESHOLD, TTL_EXTEND);
+        env.storage()
+            .instance()
+            .extend_ttl(TTL_THRESHOLD, TTL_EXTEND);
         Ok(())
     }
 
@@ -107,9 +109,11 @@ impl RefundVault {
 
         let token: Address = env.storage().instance().get(&DataKey::Token).unwrap();
         let client = token::Client::new(&env, &token);
-        client.transfer(&from, &env.current_contract_address(), &amount);
+        client.transfer(&from, env.current_contract_address(), &amount);
 
-        env.storage().instance().extend_ttl(TTL_THRESHOLD, TTL_EXTEND);
+        env.storage()
+            .instance()
+            .extend_ttl(TTL_THRESHOLD, TTL_EXTEND);
         Ok(())
     }
 
@@ -179,10 +183,14 @@ impl RefundVault {
             .persistent()
             .set(&DataKey::Refund(payment_ref.clone()), &record);
 
-        env.storage().instance().extend_ttl(TTL_THRESHOLD, TTL_EXTEND);
         env.storage()
-            .persistent()
-            .extend_ttl(&DataKey::Refund(payment_ref.clone()), TTL_THRESHOLD, TTL_EXTEND);
+            .instance()
+            .extend_ttl(TTL_THRESHOLD, TTL_EXTEND);
+        env.storage().persistent().extend_ttl(
+            &DataKey::Refund(payment_ref.clone()),
+            TTL_THRESHOLD,
+            TTL_EXTEND,
+        );
 
         Refunded {
             payment_ref,
@@ -225,7 +233,9 @@ impl RefundVault {
 
         token_client.transfer(&env.current_contract_address(), &to, &amount);
 
-        env.storage().instance().extend_ttl(TTL_THRESHOLD, TTL_EXTEND);
+        env.storage()
+            .instance()
+            .extend_ttl(TTL_THRESHOLD, TTL_EXTEND);
         Ok(())
     }
 
@@ -241,7 +251,9 @@ impl RefundVault {
             .instance()
             .set(&DataKey::RefundWindow, &ledgers);
 
-        env.storage().instance().extend_ttl(TTL_THRESHOLD, TTL_EXTEND);
+        env.storage()
+            .instance()
+            .extend_ttl(TTL_THRESHOLD, TTL_EXTEND);
         Ok(())
     }
 
@@ -260,7 +272,9 @@ impl RefundVault {
         merchant.require_auth();
 
         env.storage().instance().set(&DataKey::IsPaused, &true);
-        env.storage().instance().extend_ttl(TTL_THRESHOLD, TTL_EXTEND);
+        env.storage()
+            .instance()
+            .extend_ttl(TTL_THRESHOLD, TTL_EXTEND);
         Ok(())
     }
 
@@ -273,17 +287,25 @@ impl RefundVault {
         merchant.require_auth();
 
         env.storage().instance().set(&DataKey::IsPaused, &false);
-        env.storage().instance().extend_ttl(TTL_THRESHOLD, TTL_EXTEND);
+        env.storage()
+            .instance()
+            .extend_ttl(TTL_THRESHOLD, TTL_EXTEND);
         Ok(())
     }
 
     pub fn extend_refund_ttl(env: Env, payment_ref: BytesN<32>) -> Result<(), Error> {
-        if !env.storage().persistent().has(&DataKey::Refund(payment_ref.clone())) {
+        if !env
+            .storage()
+            .persistent()
+            .has(&DataKey::Refund(payment_ref.clone()))
+        {
             return Err(Error::RefundNotFound);
         }
-        env.storage()
-            .persistent()
-            .extend_ttl(&DataKey::Refund(payment_ref), TTL_THRESHOLD, TTL_EXTEND);
+        env.storage().persistent().extend_ttl(
+            &DataKey::Refund(payment_ref),
+            TTL_THRESHOLD,
+            TTL_EXTEND,
+        );
         Ok(())
     }
 }

--- a/contracts/refund-vault/src/test.rs
+++ b/contracts/refund-vault/src/test.rs
@@ -313,3 +313,27 @@ fn test_unpause_requires_merchant_auth() {
     env.set_auths(&[]);
     client.unpause();
 }
+
+#[test]
+fn test_extend_refund_ttl_fails_if_missing() {
+    let (env, client, merchant, _token) = setup(100);
+    client.deposit(&merchant, &500_000);
+    let payment_ref = BytesN::from_array(&env, &[99u8; 32]);
+    assert_eq!(
+        client.try_extend_refund_ttl(&payment_ref),
+        Err(Ok(Error::RefundNotFound))
+    );
+}
+
+#[test]
+fn test_extend_refund_ttl_succeeds() {
+    let (env, client, merchant, _token) = setup(100);
+    client.deposit(&merchant, &500_000);
+
+    let payment_ref = BytesN::from_array(&env, &[7u8; 32]);
+    let buyer = Address::generate(&env);
+    client.refund(&payment_ref, &buyer, &120_000, &0);
+
+    // This shouldn't fail since the refund exists.
+    client.extend_refund_ttl(&payment_ref);
+}


### PR DESCRIPTION
## Summary
The previous TTL extensions used hardcoded `(100, 100000)` values across all writes. This PR introduces a deliberate, unified strategy using named constants to guarantee 30-day longevity for records before they are archived. It also exposes public functions allowing anyone to proactively prevent records from being archived.

## What changed
- Created `TTL_THRESHOLD = 100` and `TTL_EXTEND = 518_400` (~30 days) constants in both `receipt-anchor` and `refund-vault`.
- Replaced all hardcoded storage TTL bumps with these named constants.
- Added `extend_batch_ttl(batch_id)` to `ReceiptAnchor`.
- Added `extend_refund_ttl(payment_ref)` to `RefundVault`.
- Updated `README.md` to document the 30-day archival mechanics and the new extension functions.

## Acceptance Criteria
- [x] Named constants for TTL threshold/extension with a comment justifying the values in ledger time.
- [x] Public `extend_batch_ttl` / `extend_refund_ttl` functions so anyone can keep records alive.
- [x] Docs section explaining archival/restore implications for verifiers.

Closes #7
