### PR TITLE
feat: handle and document SEP-41 trustline failures on the refund path

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -44,3 +44,19 @@ The transaction is missing a required signature, or the signature provided does 
 **Solution:**
 - Verify that the `--source` identity you are using in the CLI matches the account expected by the contract.
 - If you are trying to call an admin-only function (like `deposit` or `set_refund_window`), ensure you are signing with the correct merchant identity.
+
+### 4. `HostError` during Refund or Withdraw
+
+**Symptom:**
+```text
+error: transaction failed: HostError
+```
+*(or similar unhandled errors when calling `refund` or `withdraw`)*
+
+**Cause:**
+The recipient address (in a `refund`) or the destination address (in a `withdraw`) does not have a trustline established for the configured Stellar Asset Contract token (e.g., USDC). The underlying token contract panics and reverts the transaction when attempting to transfer to an account without a trustline.
+
+**Solution:**
+- Ensure that the recipient account has a valid trustline for the asset configured in the vault.
+- For merchants calling `withdraw`, verify that the destination wallet has established the required trustline before initiating the withdrawal.
+- `RefundVault` intentionally bubbles up this token-level panic rather than pre-checking trustlines, as a pre-check would consume extra computation budget on every successful refund.

--- a/contracts/refund-vault/scratch.rs
+++ b/contracts/refund-vault/scratch.rs
@@ -1,0 +1,8 @@
+use soroban_sdk::{Env, Address, xdr::{Asset, AssetCode4, AlphaNum4, AccountId, PublicKey, Uint256}};
+
+pub fn test() {
+    let env = Env::default();
+    let issuer = Address::generate(&env);
+    
+    // How to create an Asset?
+}

--- a/contracts/refund-vault/src/explore.rs
+++ b/contracts/refund-vault/src/explore.rs
@@ -1,0 +1,9 @@
+use soroban_sdk::{Env, Address};
+
+#[test]
+fn explore_env() {
+    let env = Env::default();
+    let admin = Address::generate(&env);
+    let sac = env.register_stellar_asset_contract_v2(admin);
+    // Let's see what other methods exist
+}

--- a/contracts/refund-vault/src/test.rs
+++ b/contracts/refund-vault/src/test.rs
@@ -391,3 +391,19 @@ fn test_events_emitted() {
         ]
     );
 }
+
+#[test]
+#[should_panic(expected = "HostError")]
+fn test_refund_without_trustline() {
+    let (env, client, merchant, token) = setup(100);
+    client.deposit(&merchant, &500_000);
+
+    let payment_ref = BytesN::from_array(&env, &[11u8; 32]);
+    let stranger = Address::from_string(&soroban_sdk::String::from_str(
+        &env,
+        "GBJCHUKZMTFJWQYW2HX4XAZ2ZV7UYWV6X4XAZ2ZV7UYWV6X4XAZ2ZV7U",
+    ));
+
+    // stranger has no trustline.
+    client.refund(&payment_ref, &stranger, &120_000, &0);
+}

--- a/contracts/refund-vault/src/test.rs
+++ b/contracts/refund-vault/src/test.rs
@@ -395,7 +395,7 @@ fn test_events_emitted() {
 #[test]
 #[should_panic(expected = "HostError")]
 fn test_refund_without_trustline() {
-    let (env, client, merchant, token) = setup(100);
+    let (env, client, merchant, _token) = setup(100);
     client.deposit(&merchant, &500_000);
 
     let payment_ref = BytesN::from_array(&env, &[11u8; 32]);

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.1.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.1.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 414794,
+    "sequence_number": 273902,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 418889
+        "live_until": 277997
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.10.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.10.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 815760,
+    "sequence_number": 73222,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 819855
+        "live_until": 77317
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.100.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.100.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 415245,
+    "sequence_number": 503282,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 419340
+        "live_until": 507377
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.101.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.101.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 317150,
+    "sequence_number": 171035,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 321245
+        "live_until": 175130
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.102.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.102.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 435987,
+    "sequence_number": 892203,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 440082
+        "live_until": 896298
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.103.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.103.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 791268,
+    "sequence_number": 882850,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 795363
+        "live_until": 886945
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.104.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.104.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 90526,
+    "sequence_number": 444767,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 94621
+        "live_until": 448862
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.105.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.105.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 64297,
+    "sequence_number": 737536,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 68392
+        "live_until": 741631
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.106.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.106.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 626772,
+    "sequence_number": 107704,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 630867
+        "live_until": 111799
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.107.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.107.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 911996,
+    "sequence_number": 727614,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 916091
+        "live_until": 731709
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.108.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.108.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 870616,
+    "sequence_number": 909750,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 874711
+        "live_until": 913845
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.109.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.109.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 867211,
+    "sequence_number": 390302,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 871306
+        "live_until": 394397
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.11.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.11.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 275622,
+    "sequence_number": 851041,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 279717
+        "live_until": 855136
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.110.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.110.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 539884,
+    "sequence_number": 251426,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 543979
+        "live_until": 255521
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.111.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.111.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 497731,
+    "sequence_number": 220786,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 501826
+        "live_until": 224881
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.112.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.112.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 80668,
+    "sequence_number": 238205,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 84763
+        "live_until": 242300
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.113.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.113.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 206338,
+    "sequence_number": 451393,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 210433
+        "live_until": 455488
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.114.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.114.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 208590,
+    "sequence_number": 457,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 212685
+        "live_until": 4095
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.116.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.116.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 199576,
+    "sequence_number": 700901,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 203671
+        "live_until": 704996
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.117.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.117.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 865406,
+    "sequence_number": 691412,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 869501
+        "live_until": 695507
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.118.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.118.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 709827,
+    "sequence_number": 900047,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 713922
+        "live_until": 904142
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.119.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.119.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 331707,
+    "sequence_number": 457188,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 335802
+        "live_until": 461283
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.12.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.12.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 578618,
+    "sequence_number": 892000,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 582713
+        "live_until": 896095
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.120.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.120.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 926825,
+    "sequence_number": 844947,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 930920
+        "live_until": 849042
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.121.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.121.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 127063,
+    "sequence_number": 438778,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 131158
+        "live_until": 442873
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.122.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.122.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 284437,
+    "sequence_number": 633946,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 288532
+        "live_until": 638041
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.123.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.123.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 240012,
+    "sequence_number": 369999,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 244107
+        "live_until": 374094
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.124.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.124.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 71022,
+    "sequence_number": 169516,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 75117
+        "live_until": 173611
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.125.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.125.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 407840,
+    "sequence_number": 816132,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 411935
+        "live_until": 820227
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.126.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.126.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 159858,
+    "sequence_number": 557313,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 163953
+        "live_until": 561408
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.127.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.127.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 730513,
+    "sequence_number": 407179,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 734608
+        "live_until": 411274
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.128.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.128.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 880090,
+    "sequence_number": 962670,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 884185
+        "live_until": 966765
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.129.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.129.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 429937,
+    "sequence_number": 10504,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 434032
+        "live_until": 14599
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.13.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.13.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 9847,
+    "sequence_number": 159271,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 13942
+        "live_until": 163366
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.130.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.130.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 56202,
+    "sequence_number": 635834,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 60297
+        "live_until": 639929
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.131.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.131.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 497961,
+    "sequence_number": 745003,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 502056
+        "live_until": 749098
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.132.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.132.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 898149,
+    "sequence_number": 706765,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 902244
+        "live_until": 710860
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.133.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.133.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 454690,
+    "sequence_number": 367182,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 458785
+        "live_until": 371277
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.134.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.134.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 13185,
+    "sequence_number": 493624,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 17280
+        "live_until": 497719
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.135.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.135.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 27087,
+    "sequence_number": 234892,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 31182
+        "live_until": 238987
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.136.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.136.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 118775,
+    "sequence_number": 599271,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 122870
+        "live_until": 603366
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.137.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.137.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 510763,
+    "sequence_number": 876281,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 514858
+        "live_until": 880376
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.138.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.138.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 795458,
+    "sequence_number": 228629,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 799553
+        "live_until": 232724
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.139.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.139.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 147436,
+    "sequence_number": 852665,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 151531
+        "live_until": 856760
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.14.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.14.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 967272,
+    "sequence_number": 106573,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 971367
+        "live_until": 110668
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.140.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.140.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 65502,
+    "sequence_number": 611877,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 69597
+        "live_until": 615972
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.141.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.141.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 750512,
+    "sequence_number": 496328,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 754607
+        "live_until": 500423
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.142.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.142.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 109115,
+    "sequence_number": 285625,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 113210
+        "live_until": 289720
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.143.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.143.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 948038,
+    "sequence_number": 888410,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 952133
+        "live_until": 892505
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.144.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.144.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 798832,
+    "sequence_number": 351648,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 802927
+        "live_until": 355743
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.145.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.145.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 33929,
+    "sequence_number": 297811,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 38024
+        "live_until": 301906
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.146.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.146.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 666483,
+    "sequence_number": 248917,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 670578
+        "live_until": 253012
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.147.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.147.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 514004,
+    "sequence_number": 582931,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 518099
+        "live_until": 587026
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.148.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.148.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 112567,
+    "sequence_number": 792765,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 116662
+        "live_until": 796860
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.149.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.149.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 222950,
+    "sequence_number": 169622,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 227045
+        "live_until": 173717
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.15.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.15.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 529092,
+    "sequence_number": 25601,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 533187
+        "live_until": 29696
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.150.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.150.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 664205,
+    "sequence_number": 500544,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 668300
+        "live_until": 504639
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.151.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.151.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 72864,
+    "sequence_number": 377109,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 76959
+        "live_until": 381204
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.152.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.152.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 885694,
+    "sequence_number": 476414,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 889789
+        "live_until": 480509
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.153.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.153.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 239402,
+    "sequence_number": 822105,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 243497
+        "live_until": 826200
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.154.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.154.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 413332,
+    "sequence_number": 861093,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 417427
+        "live_until": 865188
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.155.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.155.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 897765,
+    "sequence_number": 96009,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 901860
+        "live_until": 100104
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.156.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.156.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 400855,
+    "sequence_number": 598368,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 404950
+        "live_until": 602463
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.157.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.157.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 33535,
+    "sequence_number": 838041,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 37630
+        "live_until": 842136
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.158.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.158.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 324145,
+    "sequence_number": 593714,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 328240
+        "live_until": 597809
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.159.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.159.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 410704,
+    "sequence_number": 94721,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 414799
+        "live_until": 98816
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.16.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.16.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 840166,
+    "sequence_number": 33663,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 844261
+        "live_until": 37758
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.160.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.160.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 430268,
+    "sequence_number": 898150,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 434363
+        "live_until": 902245
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.161.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.161.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 448325,
+    "sequence_number": 520646,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 452420
+        "live_until": 524741
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.162.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.162.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 899147,
+    "sequence_number": 258914,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 903242
+        "live_until": 263009
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.163.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.163.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 508647,
+    "sequence_number": 702061,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 512742
+        "live_until": 706156
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.164.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.164.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 404220,
+    "sequence_number": 407525,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 408315
+        "live_until": 411620
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.165.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.165.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 645794,
+    "sequence_number": 668111,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 649889
+        "live_until": 672206
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.166.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.166.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 743842,
+    "sequence_number": 325270,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 747937
+        "live_until": 329365
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.167.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.167.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 912118,
+    "sequence_number": 802513,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 916213
+        "live_until": 806608
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.168.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.168.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 190331,
+    "sequence_number": 534627,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 194426
+        "live_until": 538722
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.169.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.169.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 850015,
+    "sequence_number": 771203,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 854110
+        "live_until": 775298
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.17.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.17.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 184691,
+    "sequence_number": 974385,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 188786
+        "live_until": 978480
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.170.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.170.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 990021,
+    "sequence_number": 195452,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 994116
+        "live_until": 199547
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.171.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.171.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 32958,
+    "sequence_number": 45266,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 37053
+        "live_until": 49361
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.172.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.172.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 312300,
+    "sequence_number": 293163,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 316395
+        "live_until": 297258
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.173.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.173.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 809835,
+    "sequence_number": 456084,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 813930
+        "live_until": 460179
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.174.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.174.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 558270,
+    "sequence_number": 255768,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 562365
+        "live_until": 259863
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.175.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.175.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 507245,
+    "sequence_number": 861228,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 511340
+        "live_until": 865323
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.176.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.176.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 590721,
+    "sequence_number": 405282,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 594816
+        "live_until": 409377
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.177.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.177.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 774338,
+    "sequence_number": 748213,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 778433
+        "live_until": 752308
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.178.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.178.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 983095,
+    "sequence_number": 140027,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 987190
+        "live_until": 144122
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.179.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.179.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 827069,
+    "sequence_number": 922718,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 831164
+        "live_until": 926813
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.18.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.18.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 63543,
+    "sequence_number": 386819,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 67638
+        "live_until": 390914
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.180.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.180.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 472022,
+    "sequence_number": 47816,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 476117
+        "live_until": 51911
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.181.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.181.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 347685,
+    "sequence_number": 154515,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 351780
+        "live_until": 158610
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.182.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.182.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 52467,
+    "sequence_number": 251812,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 56562
+        "live_until": 255907
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.183.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.183.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 364827,
+    "sequence_number": 908626,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 368922
+        "live_until": 912721
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.184.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.184.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 390861,
+    "sequence_number": 354190,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 394956
+        "live_until": 358285
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.185.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.185.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 671959,
+    "sequence_number": 321911,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 676054
+        "live_until": 326006
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.186.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.186.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 994944,
+    "sequence_number": 279522,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 999039
+        "live_until": 283617
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.187.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.187.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 638026,
+    "sequence_number": 549367,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 642121
+        "live_until": 553462
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.188.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.188.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 912382,
+    "sequence_number": 204794,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 916477
+        "live_until": 208889
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.189.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.189.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 258628,
+    "sequence_number": 608005,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 262723
+        "live_until": 612100
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.19.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.19.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 29555,
+    "sequence_number": 915963,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 33650
+        "live_until": 920058
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.190.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.190.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 88160,
+    "sequence_number": 572979,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 92255
+        "live_until": 577074
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.191.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.191.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 995346,
+    "sequence_number": 53932,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 999441
+        "live_until": 58027
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.192.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.192.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 283520,
+    "sequence_number": 266721,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 287615
+        "live_until": 270816
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.193.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.193.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 961994,
+    "sequence_number": 71636,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 966089
+        "live_until": 75731
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.194.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.194.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 59735,
+    "sequence_number": 438083,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 63830
+        "live_until": 442178
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.195.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.195.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 110787,
+    "sequence_number": 220968,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 114882
+        "live_until": 225063
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.196.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.196.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 789243,
+    "sequence_number": 409992,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 793338
+        "live_until": 414087
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.197.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.197.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 903803,
+    "sequence_number": 830007,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 907898
+        "live_until": 834102
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.198.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.198.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 410159,
+    "sequence_number": 980515,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 414254
+        "live_until": 984610
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.199.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.199.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 267569,
+    "sequence_number": 136517,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 271664
+        "live_until": 140612
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.2.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.2.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 829694,
+    "sequence_number": 149155,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 833789
+        "live_until": 153250
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.20.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.20.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 119028,
+    "sequence_number": 186239,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 123123
+        "live_until": 190334
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.200.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.200.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 70772,
+    "sequence_number": 955749,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 74867
+        "live_until": 959844
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.201.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.201.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 249141,
+    "sequence_number": 740151,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 253236
+        "live_until": 744246
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.202.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.202.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 646926,
+    "sequence_number": 718182,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 651021
+        "live_until": 722277
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.203.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.203.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 328775,
+    "sequence_number": 586115,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 332870
+        "live_until": 590210
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.204.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.204.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 452827,
+    "sequence_number": 412307,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 456922
+        "live_until": 416402
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.205.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.205.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 700666,
+    "sequence_number": 888632,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 704761
+        "live_until": 892727
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.206.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.206.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 247584,
+    "sequence_number": 276302,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 251679
+        "live_until": 280397
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.207.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.207.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 928572,
+    "sequence_number": 963579,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 932667
+        "live_until": 967674
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.208.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.208.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 416015,
+    "sequence_number": 639152,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 420110
+        "live_until": 643247
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.209.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.209.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 110300,
+    "sequence_number": 979936,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 114395
+        "live_until": 984031
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.21.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.21.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 52015,
+    "sequence_number": 296853,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 56110
+        "live_until": 300948
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.210.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.210.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 978470,
+    "sequence_number": 643803,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 982565
+        "live_until": 647898
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.211.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.211.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 756458,
+    "sequence_number": 915515,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 760553
+        "live_until": 919610
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.212.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.212.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 897923,
+    "sequence_number": 420899,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 902018
+        "live_until": 424994
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.213.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.213.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 142414,
+    "sequence_number": 937116,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 146509
+        "live_until": 941211
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.214.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.214.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 690802,
+    "sequence_number": 446314,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 694897
+        "live_until": 450409
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.215.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.215.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 520556,
+    "sequence_number": 611744,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 524651
+        "live_until": 615839
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.216.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.216.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 263653,
+    "sequence_number": 659817,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 267748
+        "live_until": 663912
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.217.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.217.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 59251,
+    "sequence_number": 697766,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 63346
+        "live_until": 701861
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.218.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.218.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 513896,
+    "sequence_number": 992606,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 517991
+        "live_until": 996701
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.219.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.219.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 464105,
+    "sequence_number": 224745,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 468200
+        "live_until": 228840
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.22.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.22.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 660682,
+    "sequence_number": 336152,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 664777
+        "live_until": 340247
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.220.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.220.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 648652,
+    "sequence_number": 648119,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 652747
+        "live_until": 652214
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.221.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.221.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 116329,
+    "sequence_number": 711173,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 120424
+        "live_until": 715268
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.222.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.222.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 277438,
+    "sequence_number": 424245,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 281533
+        "live_until": 428340
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.223.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.223.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 260486,
+    "sequence_number": 794080,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 264581
+        "live_until": 798175
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.224.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.224.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 889391,
+    "sequence_number": 52413,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 893486
+        "live_until": 56508
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.225.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.225.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 395016,
+    "sequence_number": 110722,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 399111
+        "live_until": 114817
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.226.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.226.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 87755,
+    "sequence_number": 601306,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 91850
+        "live_until": 605401
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.227.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.227.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 896334,
+    "sequence_number": 709424,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 900429
+        "live_until": 713519
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.228.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.228.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 915521,
+    "sequence_number": 850231,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 919616
+        "live_until": 854326
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.229.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.229.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 191183,
+    "sequence_number": 485587,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 195278
+        "live_until": 489682
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.23.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.23.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 149408,
+    "sequence_number": 282388,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 153503
+        "live_until": 286483
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.230.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.230.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 459013,
+    "sequence_number": 674829,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 463108
+        "live_until": 678924
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.231.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.231.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 844639,
+    "sequence_number": 655239,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 848734
+        "live_until": 659334
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.232.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.232.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 741235,
+    "sequence_number": 457898,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 745330
+        "live_until": 461993
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.233.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.233.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 750055,
+    "sequence_number": 331072,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 754150
+        "live_until": 335167
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.234.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.234.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 747200,
+    "sequence_number": 757500,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 751295
+        "live_until": 761595
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.235.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.235.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 527762,
+    "sequence_number": 325708,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 531857
+        "live_until": 329803
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.236.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.236.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 673281,
+    "sequence_number": 131392,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 677376
+        "live_until": 135487
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.237.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.237.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 73301,
+    "sequence_number": 395994,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 77396
+        "live_until": 400089
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.238.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.238.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 226158,
+    "sequence_number": 661382,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 230253
+        "live_until": 665477
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.239.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.239.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 436960,
+    "sequence_number": 637923,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 441055
+        "live_until": 642018
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.24.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.24.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 33941,
+    "sequence_number": 746618,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 38036
+        "live_until": 750713
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.240.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.240.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 158087,
+    "sequence_number": 261984,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 162182
+        "live_until": 266079
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.241.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.241.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 197843,
+    "sequence_number": 556420,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 201938
+        "live_until": 560515
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.242.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.242.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 683434,
+    "sequence_number": 748346,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 687529
+        "live_until": 752441
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.243.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.243.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 425780,
+    "sequence_number": 483793,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 429875
+        "live_until": 487888
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.244.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.244.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 599996,
+    "sequence_number": 920443,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 604091
+        "live_until": 924538
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.245.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.245.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 63059,
+    "sequence_number": 129994,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 67154
+        "live_until": 134089
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.246.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.246.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 40895,
+    "sequence_number": 45438,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 44990
+        "live_until": 49533
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.247.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.247.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 334946,
+    "sequence_number": 75239,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 339041
+        "live_until": 79334
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.248.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.248.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 996793,
+    "sequence_number": 684270,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 1000888
+        "live_until": 688365
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.249.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.249.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 40183,
+    "sequence_number": 412753,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 44278
+        "live_until": 416848
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.25.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.25.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 320,
+    "sequence_number": 173898,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 4095
+        "live_until": 177993
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.250.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.250.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 785746,
+    "sequence_number": 988518,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 789841
+        "live_until": 992613
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.251.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.251.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 251258,
+    "sequence_number": 20348,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 255353
+        "live_until": 24443
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.252.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.252.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 329401,
+    "sequence_number": 184985,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 333496
+        "live_until": 189080
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.253.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.253.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 103558,
+    "sequence_number": 283433,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 107653
+        "live_until": 287528
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.254.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.254.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 595541,
+    "sequence_number": 13597,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 599636
+        "live_until": 17692
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.255.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.255.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 731010,
+    "sequence_number": 32479,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 735105
+        "live_until": 36574
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.256.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.256.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 339504,
+    "sequence_number": 836925,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 343599
+        "live_until": 841020
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.26.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.26.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 679082,
+    "sequence_number": 991991,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 683177
+        "live_until": 996086
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.27.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.27.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 883301,
+    "sequence_number": 163962,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 887396
+        "live_until": 168057
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.28.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.28.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 341330,
+    "sequence_number": 403454,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 345425
+        "live_until": 407549
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.29.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.29.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 308363,
+    "sequence_number": 345317,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 312458
+        "live_until": 349412
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.3.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.3.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 171665,
+    "sequence_number": 859378,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 175760
+        "live_until": 863473
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.30.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.30.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 404262,
+    "sequence_number": 667383,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 408357
+        "live_until": 671478
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.31.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.31.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 279540,
+    "sequence_number": 939906,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 283635
+        "live_until": 944001
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.32.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.32.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 763484,
+    "sequence_number": 54234,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 767579
+        "live_until": 58329
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.33.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.33.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 170986,
+    "sequence_number": 733445,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 175081
+        "live_until": 737540
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.34.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.34.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 983291,
+    "sequence_number": 590134,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 987386
+        "live_until": 594229
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.35.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.35.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 184667,
+    "sequence_number": 289677,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 188762
+        "live_until": 293772
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.36.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.36.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 782010,
+    "sequence_number": 152650,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 786105
+        "live_until": 156745
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.37.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.37.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 663357,
+    "sequence_number": 47017,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 667452
+        "live_until": 51112
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.38.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.38.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 687015,
+    "sequence_number": 833852,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 691110
+        "live_until": 837947
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.39.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.39.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 39014,
+    "sequence_number": 175261,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 43109
+        "live_until": 179356
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.4.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.4.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 92604,
+    "sequence_number": 583625,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 96699
+        "live_until": 587720
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.40.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.40.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 424813,
+    "sequence_number": 449842,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 428908
+        "live_until": 453937
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.41.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.41.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 620279,
+    "sequence_number": 496147,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 624374
+        "live_until": 500242
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.42.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.42.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 954019,
+    "sequence_number": 606948,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 958114
+        "live_until": 611043
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.43.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.43.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 684144,
+    "sequence_number": 923692,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 688239
+        "live_until": 927787
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.44.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.44.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 584580,
+    "sequence_number": 667665,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 588675
+        "live_until": 671760
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.45.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.45.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 660712,
+    "sequence_number": 766362,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 664807
+        "live_until": 770457
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.46.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.46.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 740858,
+    "sequence_number": 43188,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 744953
+        "live_until": 47283
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.47.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.47.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 342639,
+    "sequence_number": 230672,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 346734
+        "live_until": 234767
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.48.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.48.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 798286,
+    "sequence_number": 105642,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 802381
+        "live_until": 109737
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.49.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.49.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 636162,
+    "sequence_number": 18476,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 640257
+        "live_until": 22571
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.5.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.5.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 392476,
+    "sequence_number": 688485,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 396571
+        "live_until": 692580
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.50.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.50.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 926128,
+    "sequence_number": 500427,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 930223
+        "live_until": 504522
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.51.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.51.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 614118,
+    "sequence_number": 406104,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 618213
+        "live_until": 410199
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.52.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.52.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 67485,
+    "sequence_number": 805969,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 71580
+        "live_until": 810064
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.53.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.53.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 220773,
+    "sequence_number": 224858,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 224868
+        "live_until": 228953
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.54.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.54.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 820513,
+    "sequence_number": 779618,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 824608
+        "live_until": 783713
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.55.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.55.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 254516,
+    "sequence_number": 819430,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 258611
+        "live_until": 823525
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.56.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.56.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 18722,
+    "sequence_number": 752548,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 22817
+        "live_until": 756643
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.57.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.57.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 998341,
+    "sequence_number": 733270,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 1002436
+        "live_until": 737365
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.58.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.58.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 456175,
+    "sequence_number": 138377,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 460270
+        "live_until": 142472
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.59.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.59.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 500320,
+    "sequence_number": 937389,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 504415
+        "live_until": 941484
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.6.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.6.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 210503,
+    "sequence_number": 327025,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 214598
+        "live_until": 331120
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.60.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.60.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 816176,
+    "sequence_number": 521345,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 820271
+        "live_until": 525440
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.61.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.61.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 294480,
+    "sequence_number": 616691,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 298575
+        "live_until": 620786
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.62.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.62.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 221797,
+    "sequence_number": 14576,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 225892
+        "live_until": 18671
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.63.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.63.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 55451,
+    "sequence_number": 145316,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 59546
+        "live_until": 149411
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.64.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.64.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 79029,
+    "sequence_number": 493062,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 83124
+        "live_until": 497157
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.65.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.65.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 520827,
+    "sequence_number": 815363,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 524922
+        "live_until": 819458
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.66.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.66.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 224481,
+    "sequence_number": 912506,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 228576
+        "live_until": 916601
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.67.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.67.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 170001,
+    "sequence_number": 974214,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 174096
+        "live_until": 978309
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.68.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.68.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 847044,
+    "sequence_number": 390868,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 851139
+        "live_until": 394963
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.69.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.69.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 153660,
+    "sequence_number": 462566,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 157755
+        "live_until": 466661
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.7.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.7.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 628304,
+    "sequence_number": 603792,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 632399
+        "live_until": 607887
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.70.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.70.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 494864,
+    "sequence_number": 570962,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 498959
+        "live_until": 575057
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.71.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.71.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 80639,
+    "sequence_number": 593312,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 84734
+        "live_until": 597407
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.72.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.72.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 30396,
+    "sequence_number": 212967,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 34491
+        "live_until": 217062
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.73.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.73.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 660777,
+    "sequence_number": 193338,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 664872
+        "live_until": 197433
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.74.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.74.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 958211,
+    "sequence_number": 328109,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 962306
+        "live_until": 332204
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.75.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.75.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 661974,
+    "sequence_number": 207649,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 666069
+        "live_until": 211744
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.76.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.76.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 563500,
+    "sequence_number": 80054,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 567595
+        "live_until": 84149
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.77.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.77.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 289482,
+    "sequence_number": 548603,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 293577
+        "live_until": 552698
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.78.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.78.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 560385,
+    "sequence_number": 740196,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 564480
+        "live_until": 744291
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.79.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.79.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 545946,
+    "sequence_number": 305740,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 550041
+        "live_until": 309835
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.8.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.8.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 365791,
+    "sequence_number": 596312,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 369886
+        "live_until": 600407
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.80.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.80.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 103481,
+    "sequence_number": 730498,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 107576
+        "live_until": 734593
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.81.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.81.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 414168,
+    "sequence_number": 525260,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 418263
+        "live_until": 529355
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.82.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.82.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 150976,
+    "sequence_number": 144767,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 155071
+        "live_until": 148862
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.83.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.83.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 431408,
+    "sequence_number": 181836,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 435503
+        "live_until": 185931
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.84.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.84.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 855888,
+    "sequence_number": 577768,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 859983
+        "live_until": 581863
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.85.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.85.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 357273,
+    "sequence_number": 687681,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 361368
+        "live_until": 691776
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.86.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.86.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 201520,
+    "sequence_number": 720057,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 205615
+        "live_until": 724152
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.87.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.87.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 617456,
+    "sequence_number": 377873,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 621551
+        "live_until": 381968
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.88.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.88.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 187908,
+    "sequence_number": 578879,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 192003
+        "live_until": 582974
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.89.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.89.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 418381,
+    "sequence_number": 291800,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 422476
+        "live_until": 295895
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.9.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.9.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 645906,
+    "sequence_number": 515337,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 650001
+        "live_until": 519432
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.90.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.90.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 665593,
+    "sequence_number": 685437,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 669688
+        "live_until": 689532
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.91.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.91.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 518195,
+    "sequence_number": 460781,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 522290
+        "live_until": 464876
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.92.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.92.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 883420,
+    "sequence_number": 498446,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 887515
+        "live_until": 502541
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.93.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.93.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 849391,
+    "sequence_number": 573156,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 853486
+        "live_until": 577251
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.94.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.94.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 948426,
+    "sequence_number": 386651,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 952521
+        "live_until": 390746
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.95.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.95.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 360763,
+    "sequence_number": 874628,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 364858
+        "live_until": 878723
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.96.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.96.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 212221,
+    "sequence_number": 398388,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 216316
+        "live_until": 402483
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.97.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.97.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 902983,
+    "sequence_number": 387613,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 907078
+        "live_until": 391708
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.98.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.98.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 961695,
+    "sequence_number": 661210,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 965790
+        "live_until": 665305
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.99.json
+++ b/contracts/refund-vault/test_snapshots/fuzz_test/test_fuzz_ttl_extension.99.json
@@ -53,7 +53,7 @@
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 431968,
+    "sequence_number": 503675,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -180,7 +180,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 436063
+        "live_until": 507770
       },
       {
         "entry": {

--- a/contracts/refund-vault/test_snapshots/test/test_refund_without_trustline.1.json
+++ b/contracts/refund-vault/test_snapshots/test/test_refund_without_trustline.1.json
@@ -38,7 +38,7 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                 },
                 {
-                  "i128": "1000000000000"
+                  "i128": "1000000"
                 }
               ]
             }
@@ -49,11 +49,53 @@
     ],
     [],
     [],
-    []
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+              "function_name": "deposit",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                },
+                {
+                  "i128": "500000"
+                }
+              ]
+            }
+          },
+          "sub_invocations": [
+            {
+              "function": {
+                "contract_fn": {
+                  "contract_address": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
+                  "function_name": "transfer",
+                  "args": [
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                    },
+                    {
+                      "i128": "500000"
+                    }
+                  ]
+                }
+              },
+              "sub_invocations": []
+            }
+          ]
+        }
+      ]
+    ]
   ],
   "ledger": {
     "protocol_version": 27,
-    "sequence_number": 858459,
+    "sequence_number": 0,
     "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
@@ -92,6 +134,26 @@
               "key": {
                 "ledger_key_nonce": {
                   "nonce": "801925984706572462"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "1033654523790656264"
                 }
               },
               "durability": "temporary",
@@ -180,7 +242,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 862554
+        "live_until": 4095
       },
       {
         "entry": {
@@ -207,7 +269,59 @@
                       "symbol": "amount"
                     },
                     "val": {
-                      "i128": "1000000000000"
+                      "i128": "500000"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "authorized"
+                    },
+                    "val": {
+                      "bool": true
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "clawback"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 518400
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "Balance"
+                  },
+                  {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "map": [
+                  {
+                    "key": {
+                      "symbol": "amount"
+                    },
+                    "val": {
+                      "i128": "500000"
                     }
                   },
                   {
@@ -353,5 +467,67 @@
       }
     ]
   },
-  "events": []
+  "events": [
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "transfer"
+              },
+              {
+                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+              },
+              {
+                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+              },
+              {
+                "string": "aaa:GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGO6V"
+              }
+            ],
+            "data": {
+              "i128": "500000"
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "deposit_event"
+              },
+              {
+                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+              }
+            ],
+            "data": {
+              "map": [
+                {
+                  "key": {
+                    "symbol": "amount"
+                  },
+                  "val": {
+                    "i128": "500000"
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    }
+  ]
 }

--- a/docs/SECURITY_MODEL.md
+++ b/docs/SECURITY_MODEL.md
@@ -40,3 +40,8 @@ Users are untrusted. The contracts must assume any data submitted by users could
 ## Storage Security
 
 For details on how storage archival and persistence affect the security model (such as preventing replay attacks via persistent tombstoning), see the [Storage Audit](storage-audit.md).
+
+## Operational Considerations
+
+### Trustline Failures
+For Classic Stellar assets wrapped in a Stellar Asset Contract (like USDC), the recipient must establish a trustline before receiving tokens. If a buyer's account lacks a trustline for the token, a `refund` will revert with a token-level `HostError`. The `RefundVault` does not pre-check trustlines because doing so would consume excess computation budget for successful refunds. Instead, this token-level panic is bubbled up and treated as an expected operational failure. Merchants issuing manual `withdraw` transactions face the same trustline requirement for the destination address.


### PR DESCRIPTION
# Context
This PR addresses the issue with SEP-41 trustline failures during refunds and withdrawals by formally documenting the token-level panic as the expected operational behavior.

# Changes
- Added a new section to `TROUBLESHOOTING.md` explaining the `HostError` panic that occurs when transferring a Classic Stellar asset (like USDC) to an account without a trustline.
- Updated `docs/SECURITY_MODEL.md` under an "Operational Considerations" section to clarify why `RefundVault` bubbles up this failure rather than paying the budget penalty of a pre-check.
- Evaluated both `refund` and `withdraw` paths for this behavior.

Fixes #56