### PR TITLE
fix(readme): link the published docs site, not the stale scaffold deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
   </p>
   <p>
     <a href="DEPLOYMENTS.md"><strong>Live on Testnet</strong></a> ·
-    <a href="https://accensa-docs.vercel.app"><strong>Documentation</strong></a> ·
+    <a href="https://accensa.github.io/accensa-app/docs/contracts/overview"><strong>Documentation</strong></a> ·
     <a href="https://accensa-dashboard.vercel.app"><strong>Dashboard</strong></a> ·
     <a href="https://github.com/accensa/accensa-app"><strong>accensa-app</strong></a>
   </p>


### PR DESCRIPTION
## Context

The README's "Documentation" link pointed at `accensa-docs.vercel.app` — a separate Vercel project, last deployed 31 days ago, still serving unmodified Docusaurus scaffold copy.

## Changes

Points it at this repo's section of the docs site published from `accensa-app` on 08-13:

<https://accensa.github.io/accensa-app/docs/contracts/overview>

Companion to accensa/accensa-app#113, which fixes the same stale link in the app repo, the mobile nav, and the Docusaurus `editUrl`.