### PR TITLE
feat(receipt-anchor): expose MAX_BATCH_SIZE via get_max_batch_size

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ they were charged correctly, with no trusted API in the path.
 | `anchor_batch(root, count, period_start, period_end) -> u64` | Anchors a batch root, returns its `batch_id`. Merchant auth required. `count` must be $\le$ 1000 (`MAX_BATCH_SIZE`). |
 | `get_batch(batch_id) -> BatchRecord` | Reads an anchored batch. |
 | `get_batch_count() -> u64` | Returns the total number of anchored batches. Read-only. |
+| `get_max_batch_size() -> u32` | Returns `MAX_BATCH_SIZE` (currently 1000). Read-only; clients should discover the limit via this getter rather than hard-coding it. |
 | `verify_receipt(batch_id, leaf, proof) -> bool` | Verifies a receipt against the anchored root. Read-only, free to call. |
 | `extend_batch_ttl(batch_id)` | Extends the TTL of a batch to prevent archival. Publicly callable. |
 | `prune_batches(before_ledger)` | Deletes anchored batches older than `before_ledger` to reclaim rent. Merchant auth required. |
@@ -73,6 +74,8 @@ they were charged correctly, with no trusted API in the path.
 Pruning walks forward from an internal `PrunedUpTo` cursor and stops at the first batch
 that is not old enough, so the deleted range always stays a contiguous prefix — a batch
 is never removed from the middle while older ones remain readable.
+
+`MAX_BATCH_SIZE` (1000) caps how many receipts may appear in one `anchor_batch`. Call `get_max_batch_size` to discover the limit at runtime instead of hard-coding it.
 
 Emits:
 

--- a/contracts/receipt-anchor/src/lib.rs
+++ b/contracts/receipt-anchor/src/lib.rs
@@ -190,6 +190,14 @@ impl ReceiptAnchor {
             .ok_or(Error::NotInitialized)
     }
 
+    /// Returns the maximum number of receipts allowed in a single `anchor_batch`.
+    ///
+    /// Clients should call this rather than hard-coding the limit so they stay
+    /// in sync if the constant is ever tuned.
+    pub fn get_max_batch_size(_env: Env) -> u32 {
+        MAX_BATCH_SIZE
+    }
+
     pub fn extend_batch_ttl(env: Env, batch_id: u64) -> Result<(), Error> {
         if !env.storage().persistent().has(&DataKey::Batch(batch_id)) {
             return Err(Error::BatchNotFound);

--- a/contracts/receipt-anchor/src/test.rs
+++ b/contracts/receipt-anchor/src/test.rs
@@ -193,13 +193,32 @@ fn test_get_batch_count_before_initialize_fails() {
 }
 
 #[test]
+fn test_get_max_batch_size() {
+    let (_env, client, _merchant) = setup();
+    assert_eq!(client.get_max_batch_size(), MAX_BATCH_SIZE);
+    assert_eq!(client.get_max_batch_size(), 1000);
+}
+
+#[test]
+fn test_anchor_batch_at_max_size_succeeds() {
+    let (env, client, merchant) = setup();
+    client.initialize(&merchant);
+
+    let root = BytesN::from_array(&env, &[1u8; 32]);
+    let batch_id = client.anchor_batch(&root, &MAX_BATCH_SIZE, &0, &50);
+    assert_eq!(batch_id, 1);
+    let record = client.get_batch(&batch_id);
+    assert_eq!(record.count, MAX_BATCH_SIZE);
+}
+
+#[test]
 fn test_anchor_batch_enforces_max_size() {
     let (env, client, merchant) = setup();
     client.initialize(&merchant);
 
     let root = BytesN::from_array(&env, &[1u8; 32]);
     assert_eq!(
-        client.try_anchor_batch(&root, &1001, &0, &50),
+        client.try_anchor_batch(&root, &(MAX_BATCH_SIZE + 1), &0, &50),
         Err(Ok(Error::BatchTooLarge))
     );
 }


### PR DESCRIPTION
## Summary
`MAX_BATCH_SIZE` was enforced privately inside `anchor_batch` with no way for clients (or the `accensa-app` indexer) to discover it without hard-coding or failing in production.

This PR:
1. Adds `get_max_batch_size() -> u32` returning the constant
2. Documents the getter and limit in `README.md`
3. Adds boundary tests: exactly `MAX_BATCH_SIZE` succeeds; `MAX_BATCH_SIZE + 1` returns `BatchTooLarge`
4. Keeps the limit non-configurable (out of scope per issue)

## Follow-up
A follow-up should be filed in `accensa-app` so the indexer reads the limit via the getter instead of assuming 1000.

## Test plan
- [x] `cargo test -p receipt-anchor` — 26 passed, including `test_get_max_batch_size`, `test_anchor_batch_at_max_size_succeeds`, `test_anchor_batch_enforces_max_size`

Closes #161