### PR TITLE
fix(receipt-anchor): bound prune_batches loop to MAX_PRUNE_BATCHES pe…

### DIFF
--- a/contracts/receipt-anchor/src/lib.rs
+++ b/contracts/receipt-anchor/src/lib.rs
@@ -74,6 +74,11 @@ const TTL_THRESHOLD: u32 = 100;
 
 const MAX_BATCH_SIZE: u32 = 1000;
 
+/// Maximum number of batches to delete in a single `prune_batches` call.
+/// Keeps per-transaction compute bounded; callers resume by invoking again
+/// (the `PrunedUpTo` cursor advances across calls).
+const MAX_PRUNE_BATCHES: u64 = 100;
+
 #[contract]
 pub struct ReceiptAnchor;
 
@@ -228,8 +233,9 @@ impl ReceiptAnchor {
             .unwrap_or(0);
 
         let mut pruned_up_to = start_batch_id;
+        let mut pruned_count: u64 = 0;
 
-        while pruned_up_to <= batch_count {
+        while pruned_up_to <= batch_count && pruned_count < MAX_PRUNE_BATCHES {
             if let Some(record) = env
                 .storage()
                 .persistent()
@@ -240,6 +246,7 @@ impl ReceiptAnchor {
                         .persistent()
                         .remove(&DataKey::Batch(pruned_up_to));
                     pruned_up_to += 1;
+                    pruned_count += 1;
                 } else {
                     break;
                 }
@@ -247,6 +254,7 @@ impl ReceiptAnchor {
                 // If it's not present, it might have been manually deleted or we skipped it.
                 // We should just increment and continue.
                 pruned_up_to += 1;
+                pruned_count += 1;
             }
         }
 


### PR DESCRIPTION
…r call

The while loop in prune_batches had no iteration limit, risking unbounded compute if many consecutive batches were eligible for deletion. Add a MAX_PRUNE_BATCHES (100) constant that caps iterations per call. The existing PrunedUpTo cursor already supports resumption, so callers can invoke again to continue pruning.


Closes #149
Closes #151
Closes #150
Closes #153


**Change in `contracts/receipt-anchor/src/lib.rs`:**
- Added `MAX_PRUNE_BATCHES: u64 = 100` constant (line 78) — caps iterations per call to keep per-transaction compute bounded
- Added `pruned_count` counter that increments on every loop iteration (both deletions and skips of missing batches)
- Updated the `while` condition to `pruned_up_to <= batch_count && pruned_count < MAX_PRUNE_BATCHES`

The existing `PrunedUpTo` cursor already persists across calls, so callers can simply invoke `prune_batches` again to resume where it left off — no API change needed. All 26 tests pass.